### PR TITLE
Add support for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "🤖 Dependencies"
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "daily"
+    labels:
+      - "🤖 Dependencies"


### PR DESCRIPTION
Hello @tchupp I noticed some of the github-actions used by this action are outdated. Dependabot will take care of creating PR's for each dependency update.

- Tracks NPM dependencies
- Tracks Github Actions dependencies